### PR TITLE
Allow any data through update

### DIFF
--- a/solr/connection.go
+++ b/solr/connection.go
@@ -146,7 +146,7 @@ func (c *Connection) Resource(source string, params *url.Values) (*[]byte, error
 }
 
 // Update take optional params which can use to specify addition parameters such as commit=true
-func (c *Connection) Update(data map[string]interface{}, params *url.Values) (*SolrUpdateResponse, error) {
+func (c *Connection) Update(data interface{}, params *url.Values) (*SolrUpdateResponse, error) {
 
 	b, err := json2bytes(data)
 

--- a/solr/solr.go
+++ b/solr/solr.go
@@ -191,8 +191,8 @@ func (si *SolrInterface) DeleteAll() (*SolrUpdateResponse, error) {
 	return si.Delete(M{"query": "*:*"}, params)
 }
 
-// Update take data of type map and optional params which can use to specify addition parameters such as commit=true
-func (si *SolrInterface) Update(data map[string]interface{}, params *url.Values) (*SolrUpdateResponse, error) {
+// Update take data of type interface{} and optional params which can use to specify addition parameters such as commit=true
+func (si *SolrInterface) Update(data interface{}, params *url.Values) (*SolrUpdateResponse, error) {
 	if si.conn == nil {
 		return nil, fmt.Errorf("No connection found for making request to solr")
 	}


### PR DESCRIPTION
The data which is sent through Update could also be an array for example `[{"id":"11","var":{"set":10}}]` which is not possible to send as `map[string]interface{}` and Marshal will accept an `interface{}` anyway.