### PR TITLE
Allow queries larger than max url limit

### DIFF
--- a/solr/connection.go
+++ b/solr/connection.go
@@ -14,6 +14,12 @@ var userAgent = fmt.Sprintf("Go-solr/%s (+https://github.com/vanng822/go-solr)",
 
 var transport = http.Transport{}
 
+// Solr imposes a limit on the size of a URL send to it using GET requests. Thus
+// this library will switch to use to POST requests as the user query's grow up.
+// If you need, you can charge this value, but be aware of the URL limit in
+// your Solr distribution.
+var MaximumSolrUrlLengthSupported = 2083
+
 // HTTPPost make a POST request to path which also includes domain, headers are optional
 func HTTPPost(path string, data *[]byte, headers [][]string, username, password string) ([]byte, error) {
 	var (
@@ -147,10 +153,9 @@ func (c *Connection) Resource(source string, params *url.Values) (*[]byte, error
 	params.Set("wt", "json")
 	baseUrl := fmt.Sprintf("%s/%s/%s", c.url.String(), c.core, source)
 	encodedParameters := params.Encode()
-	maximumUrlLength := 2083
 	var r []byte
 	var err error
-	if len(baseUrl) + len(encodedParameters) >= maximumUrlLength {
+	if len(baseUrl) + len(encodedParameters) >= MaximumSolrUrlLengthSupported {
 		data := []byte(encodedParameters)
 		var headers [][]string
 		copy(headers, c.headers)


### PR DESCRIPTION
Currently the lib uses get requests to send queries to Solr, but URLs have a maximum character limit (currently about 2K). This prevents us to execute larger queries on Solr.
To overcome this problems, as Solr also accept requests via POST, we add this possibility to the to the lib.
Moreover would be nice if the lib's user had have control over headers sent to Solr. So we also add this possibility in this PR