### PR TITLE
Add facet query option

### DIFF
--- a/solr/query.go
+++ b/solr/query.go
@@ -66,7 +66,7 @@ func (q *Query) AddFacet(f string) {
 // Example: price:[* TO 500]
 func (q *Query) AddFacetQuery(fq string) {
 	q.params.Set("facet", "true")
-	q.params.Add("facet.query", f)
+	q.params.Add("facet.query", fq)
 }
 
 // mc (Facet min count) https://cwiki.apache.org/confluence/display/solr/Faceting#Faceting-Thefacet.mincountParameter

--- a/solr/query.go
+++ b/solr/query.go
@@ -62,6 +62,13 @@ func (q *Query) AddFacet(f string) {
 	q.params.Add("facet.field", f)
 }
 
+// fq (FacetQuery) https://wiki.apache.org/solr/SimpleFacetParameters#facet.query_:_Arbitrary_Query_Faceting
+// Example: price:[* TO 500]
+func (q *Query) AddFacetQuery(fq string) {
+	q.params.Set("facet", "true")
+	q.params.Add("facet.query", f)
+}
+
 // mc (Facet min count) https://cwiki.apache.org/confluence/display/solr/Faceting#Faceting-Thefacet.mincountParameter
 // Example: 5
 func (q *Query) SetFacetMinCount(mc int) {

--- a/solr/query_test.go
+++ b/solr/query_test.go
@@ -169,6 +169,17 @@ func TestSolrQueryAddFacet(t *testing.T) {
 	}
 }
 
+func TestSolrQueryAddFacetQuery(t *testing.T) {
+	q := NewQuery()
+	q.AddFacetQuery("price:[* TO 500]")
+	q.AddFacetQuery("price:[501 TO *]")
+	expected := "facet=true&facet.query=price%3A%5B%2A+TO+500%5D&facet.query=price%3A%5B501+TO+%2A%5D"
+	result := q.String()
+	if result != expected {
+		t.Errorf("expected '%s' but got '%s'", expected, result)
+	}
+}
+
 func TestSolrQuerySetFacetMinCount(t *testing.T) {
 	q := NewQuery()
 	q.SetFacetMinCount(10)


### PR DESCRIPTION
facet.query : Arbitrary Query Faceting
This param allows you to specify an arbitrary query in the Lucene default syntax to generate a facet count. By default, faceting returns a count of the unique terms for a "field", while facet.query allows you to determine counts for arbitrary terms or expressions.

This parameter can be specified multiple times to indicate that multiple queries should be used as separate facet constraints. It can be particularly useful for numeric range based facets, or prefix based facets -- see example below (i.e. price:[* TO 500] and  price:[501 TO *]).

To specify facet queries not in the Lucene default query syntax, prefix the facet query with the name of the query notation, a la LocalParams. For example, to use the hypothetical myfunc query parser, send parameter facet.query={!myfunc}name~fred