### PR TITLE
Handle user-specific requests that are not already handled

### DIFF
--- a/solr/search.go
+++ b/solr/search.go
@@ -97,3 +97,15 @@ func (s *Search) SpellCheck(parser ResultParser) (*SolrResult, error) {
 	}
 	return parser.Parse(resp)
 }
+
+// This method is for making query to user-specific or any request handler endpoint
+func (s *Search) Any(endpoint string, parser AnyResultParser) (*SolrAnyResult, error) {
+	resp, err := s.Resource(endpoint, s.QueryParams())
+	if err != nil {
+		return nil, err
+	}
+	if parser == nil {
+		parser = new(AnyParser)
+	}
+	return parser.Parse(resp)
+}

--- a/solr/solr.go
+++ b/solr/solr.go
@@ -49,7 +49,7 @@ type FireworkCollection struct {
 
 // Parsed result for SearchHandler response, ie /select
 type FireworkSolrResult struct {
-	Status  int                // status quick access to status
+	Status  int                                  // status quick access to status
 	Results FireworkCollection `json:"response"` // results parsed documents, basically response object
 	QTime   int
 	Params  map[string]string `json:"params"`
@@ -62,7 +62,7 @@ type FireworkSolrResult struct {
 	Grouped        map[string]interface{} // grouped for grouping result if grouping Results will be empty
 	Stats          map[string]interface{}
 	MoreLikeThis   map[string]interface{} // MoreLikeThis using Search (select) Component
-	NextCursorMark string                 `json:"nextCursorMark"`
+	NextCursorMark string `json:"nextCursorMark"`
 }
 
 // Holding the search result
@@ -87,6 +87,7 @@ type SolrResult struct {
 	Stats          map[string]interface{}
 	MoreLikeThis   map[string]interface{} // MoreLikeThis using Search (select) Component
 	SpellCheck     map[string]interface{} // SpellCheck using SpellCheck (spell) Component
+	Suggest        map[string]interface{} // Suggest using Suggester (suggest) Component
 	NextCursorMark string
 }
 
@@ -97,6 +98,15 @@ type SolrMltResult struct {
 	Match          *Collection // Documents for match section
 	ResponseHeader map[string]interface{}
 	Error          map[string]interface{}
+}
+
+// Parsed result for any response that is not already handled
+type SolrAnyResult struct {
+	Status         int // status quick access to status
+	Results        *Collection // results parsed documents, basically response object
+	ResponseHeader map[string]interface{}
+	Error          map[string]interface{}
+	Payload        map[string]interface{}
 }
 
 type SolrInterface struct {

--- a/solr/solr.go
+++ b/solr/solr.go
@@ -87,7 +87,6 @@ type SolrResult struct {
 	Stats          map[string]interface{}
 	MoreLikeThis   map[string]interface{} // MoreLikeThis using Search (select) Component
 	SpellCheck     map[string]interface{} // SpellCheck using SpellCheck (spell) Component
-	Suggest        map[string]interface{} // Suggest using Suggester (suggest) Component
 	NextCursorMark string
 }
 


### PR DESCRIPTION
Every time a developer adds a new request handler with a new endpoint will need to create  its own parser which is a bit of work. Therefore, I suggest to add such handler to allow developers to painlessly handle non standard requests. While errors and status is already handled by the library.
ex:
```
        q := solr.NewQuery()
	q.AddParam("suggest.q", query)
	q.AddParam("suggest", "true")
	q.Rows(0)
	s := r.Search(q)
	res, err := s.Any("suggest", nil)
	if err != nil {
		return
	}

	fmt.Printf("%+v",  res.Payload) //we should have everything we need 
	s1, ok := res.Payload["suggest"].(map[string]interface{})
	if ok {
		//dig some more..
	}
```
