### PR TITLE
Add option for Realtime Get

### DIFF
--- a/solr/mock_test.go
+++ b/solr/mock_test.go
@@ -69,6 +69,22 @@ func mockSuccessSelect(w http.ResponseWriter, req *http.Request) {
 		  }}`)
 }
 
+func mockSuccessRealTimeGet(w http.ResponseWriter, req *http.Request) {
+	logRequest(req)
+	io.WriteString(w, `{
+		"response":{"numFound":1,"start":0,"docs":[
+			{
+			  "id":"123",
+			  "title":["test"],
+			  "_version_":1658405911050321920}]
+		}}`)
+}
+
+func mockFailRealTimeGet(w http.ResponseWriter, req *http.Request) {
+	logRequest(req)
+	io.WriteString(w, `{}`)
+}
+
 func mockSuccessSpell(w http.ResponseWriter, req *http.Request) {
 	logRequest(req)
 	io.WriteString(w, `{
@@ -419,6 +435,8 @@ func mockMoreLikeThisError(w http.ResponseWriter, req *http.Request) {
 
 func mockStartServer() {
 	http.HandleFunc("/success/core0/select/", mockSuccessSelect)
+	http.HandleFunc("/realtimegetsuccess/core0/get/", mockSuccessRealTimeGet)
+	http.HandleFunc("/realtimegetfail/core0/get/", mockFailRealTimeGet)
 	http.HandleFunc("/fail/core0/select/", mockFailSelect)
 	http.HandleFunc("/facet_counts/core0/select/", mockSuccessSelectFacet)
 	http.HandleFunc("/highlight/core0/select/", mockSuccessSelectHighlight)

--- a/solr/parser.go
+++ b/solr/parser.go
@@ -2,6 +2,7 @@ package solr
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 )
 
@@ -268,4 +269,30 @@ func (parser *MoreLikeThisParser) Parse(resp_ *[]byte) (*SolrMltResult, error) {
 		}
 	}
 	return sr, nil
+}
+
+type RealTimeGetResultParser interface {
+	Parse(*[]byte) (*SolrGetResult, error)
+}
+
+type RealTimeGetParser struct {
+}
+
+// Parse function for RealTimeGetParser
+func (parser *RealTimeGetParser) Parse(resp_ *[]byte) (*SolrGetResult, error) {
+	sr := &SolrGetResult{}
+	jsonbuf, err := bytes2json(resp_)
+	if err != nil {
+		return sr, err
+	}
+
+	sr.Results = new(Collection)
+	if resp, ok := jsonbuf["response"].(map[string]interface{}); ok {
+		ParseDocResponse(resp, sr.Results)
+	} else {
+		// Should only happen when params are incorrectly defined
+		err = errors.New("Unable to parse realtime get response")
+	}
+
+	return sr, err
 }

--- a/solr/parser.go
+++ b/solr/parser.go
@@ -272,15 +272,15 @@ func (parser *MoreLikeThisParser) Parse(resp_ *[]byte) (*SolrMltResult, error) {
 }
 
 type RealTimeGetResultParser interface {
-	Parse(*[]byte) (*SolrGetResult, error)
+	Parse(*[]byte) (*SolrRealtimeGetResult, error)
 }
 
 type RealTimeGetParser struct {
 }
 
 // Parse function for RealTimeGetParser
-func (parser *RealTimeGetParser) Parse(resp_ *[]byte) (*SolrGetResult, error) {
-	sr := &SolrGetResult{}
+func (parser *RealTimeGetParser) Parse(resp_ *[]byte) (*SolrRealtimeGetResult, error) {
+	sr := &SolrRealtimeGetResult{}
 	jsonbuf, err := bytes2json(resp_)
 	if err != nil {
 		return sr, err

--- a/solr/search.go
+++ b/solr/search.go
@@ -74,12 +74,12 @@ func (s *Search) Result(parser ResultParser) (*SolrResult, error) {
 
 // RealTimeGet makes queries to the RealTimeGetHandler
 // See https://lucene.apache.org/solr/guide/8_0/realtime-get.html
-// This currently supports only the unique-key and fq parameters
+// This currently supports only the id (unique-key) and fq parameters
+// Regardless of what actual name the unique-key field has,
+// it should be specified as id or ids in the params
 func (s *Search) RealTimeGet(parser RealTimeGetResultParser) (*SolrGetResult, error) {
 	// the response format is different with the id and ids params
-	// so the id params if present is converted to the ids param
-	// which lets the response be parsed by ParseDocResponse()
-	// see https://lucene.apache.org/solr/guide/8_0/realtime-get.html
+	// converting id to ids lets the response be parsed by ParseDocResponse()
 	if id := s.QueryParams().Get("id"); id != "" {
 		s.QueryParams().Set("ids", id)
 		s.QueryParams().Del("id")

--- a/solr/search.go
+++ b/solr/search.go
@@ -77,7 +77,7 @@ func (s *Search) Result(parser ResultParser) (*SolrResult, error) {
 // This currently supports only the id (unique-key) and fq parameters
 // Regardless of what actual name the unique-key field has,
 // it should be specified as id or ids in the params
-func (s *Search) RealTimeGet(parser RealTimeGetResultParser) (*SolrGetResult, error) {
+func (s *Search) RealTimeGet(parser RealTimeGetResultParser) (*SolrRealtimeGetResult, error) {
 	// the response format is different with the id and ids params
 	// converting id to ids lets the response be parsed by ParseDocResponse()
 	if id := s.QueryParams().Get("id"); id != "" {

--- a/solr/search.go
+++ b/solr/search.go
@@ -72,6 +72,31 @@ func (s *Search) Result(parser ResultParser) (*SolrResult, error) {
 	return parser.Parse(resp)
 }
 
+// RealTimeGet makes queries to the RealTimeGetHandler
+// See https://lucene.apache.org/solr/guide/8_0/realtime-get.html
+// This currently supports only the unique-key and fq parameters
+func (s *Search) RealTimeGet(parser RealTimeGetResultParser) (*SolrGetResult, error) {
+	// the response format is different with the id and ids params
+	// so the id params if present is converted to the ids param
+	// which lets the response be parsed by ParseDocResponse()
+	// see https://lucene.apache.org/solr/guide/8_0/realtime-get.html
+	if id := s.QueryParams().Get("id"); id != "" {
+		s.QueryParams().Set("ids", id)
+		s.QueryParams().Del("id")
+	}
+
+	resp, err := s.Resource("get", s.QueryParams())
+	if err != nil {
+		return nil, err
+	}
+
+	if parser == nil {
+		parser = new(RealTimeGetParser)
+	}
+
+	return parser.Parse(resp)
+}
+
 // This method is for making query to MoreLikeThisHandler
 // See http://wiki.apache.org/solr/MoreLikeThisHandler
 func (s *Search) MoreLikeThis(parser MltResultParser) (*SolrMltResult, error) {

--- a/solr/solr.go
+++ b/solr/solr.go
@@ -100,8 +100,8 @@ type SolrMltResult struct {
 	Error          map[string]interface{}
 }
 
-// SolrGetResult is the parsed result for the RealTimeGetHandler response ie /get
-type SolrGetResult struct {
+// SolrRealtimeGetResult is the parsed result for the RealTimeGetHandler response ie /get
+type SolrRealtimeGetResult struct {
 	Results *Collection
 }
 

--- a/solr/solr.go
+++ b/solr/solr.go
@@ -100,6 +100,11 @@ type SolrMltResult struct {
 	Error          map[string]interface{}
 }
 
+// SolrGetResult is the parsed result for the RealTimeGetHandler response ie /get
+type SolrGetResult struct {
+	Results *Collection
+}
+
 type SolrInterface struct {
 	conn *Connection
 }

--- a/solr/solr_test.go
+++ b/solr/solr_test.go
@@ -102,6 +102,48 @@ func TestSolrSuccessSelect(t *testing.T) {
 	}
 }
 
+func TestSolrRealTimeGetSuccess(t *testing.T) {
+	si, err := NewSolrInterface("http://127.0.0.1:12345/realtimegetsuccess", "core0")
+	if err != nil {
+		t.Errorf("Can not instance a new solr interface, err: %s", err)
+	}
+
+	q := NewQuery()
+	q.AddParam("id", "123")
+	s := si.Search(q)
+	res, err := s.RealTimeGet(nil)
+	if err != nil {
+		t.Errorf("cannot get %s", err)
+	}
+
+	if res.Results.NumFound != 1 {
+		t.Errorf("results.numFound expected to be 1")
+	}
+
+	if len(res.Results.Docs) != 1 {
+		t.Errorf("len of results.docs should be 1")
+	}
+
+	if res.Results.Docs[0].Get("id").(string) != "123" {
+		t.Errorf("id of document should be 123")
+	}
+}
+
+func TestSolrRealTimeGetFail(t *testing.T) {
+	si, err := NewSolrInterface("http://127.0.0.1:12345/realtimegetfail", "core0")
+	if err != nil {
+		t.Errorf("Can not instance a new solr interface, err: %s", err)
+	}
+
+	q := NewQuery()
+	q.AddParam("id", "")
+	s := si.Search(q)
+	_, err = s.RealTimeGet(nil)
+	if err == nil {
+		t.Errorf("Expected an error")
+	}
+}
+
 func TestSolrConnectionPostWithoutDataSucces(t *testing.T) {
 	_, err := HTTPPost(fmt.Sprintf("%s/collection1/schema", solrUrl), nil, nil, "", "", 0)
 	if err != nil {


### PR DESCRIPTION
From the [docs](https://lucene.apache.org/solr/guide/8_0/realtime-get.html):

The realtime get feature allows retrieval (by unique-key) of the latest version of any documents without the associated cost of reopening a searcher. This is primarily useful when using Solr as a NoSQL data store and not just a search index.

A query might be:
```
query := solr.NewQuery()
query.Q("id:123")
s := si.Search(query)
res, err := s.Result(nil)
```
while a similar get request is:
```
q := NewQuery()
q.AddParam("id", "123")
s := si.Search(q)
res, err := s.RealTimeGet(nil)
```
Any thoughts?